### PR TITLE
Fix v2 UI: scroll-to-top on nav and persist route across refresh

### DIFF
--- a/services/web/frontend/src/App.jsx
+++ b/services/web/frontend/src/App.jsx
@@ -23,13 +23,22 @@ function Icon({ children }) {
 export default function App() {
   const [state, actions] = useStore();
   const [themeMode, setThemeMode] = useTheme();
-  const [route, setRoute] = useState("overview");
+  const initialRoute = () => {
+    const h = window.location.hash.slice(1);
+    return NAV.some(n => n.k === h) ? h : "overview";
+  };
+  const [route, setRoute] = useState(initialRoute);
   const t = useMemo(() => makeT(state.locale || "en-GB"), [state.locale]);
 
   useEffect(() => {
     document.documentElement.setAttribute("data-skin", "paper");
     document.documentElement.setAttribute("data-density", "cozy");
   }, []);
+
+  useEffect(() => {
+    window.location.hash = route;
+    window.scrollTo(0, 0);
+  }, [route]);
 
   if (!state.loaded) {
     return (


### PR DESCRIPTION
Use window.location.hash to store the active route so refreshing lands on the same page. Reset scroll to top whenever the route changes.