### PR TITLE
Allow vertical scroll over the dial on touch devices

### DIFF
--- a/services/web/frontend/src/styles.css
+++ b/services/web/frontend/src/styles.css
@@ -291,7 +291,7 @@ body {
 }
 .dial-svg {
   width: 100%; height: 100%;
-  user-select: none; touch-action: none;
+  user-select: none; touch-action: pan-y;
   cursor: grab;
 }
 .dial-svg.dragging { cursor: grabbing; }


### PR DESCRIPTION
The dial SVG had touch-action: none across its entire 480x480 box, including the empty center, which blocked page scrolling whenever a finger started inside that area. Switch to pan-y so the browser handles vertical scroll natively; the dial's circular drag still works because rotation is mostly non-vertical motion.