### PR TITLE
Fix dial and history touch handling on Chrome/Edge mobile

### DIFF
--- a/services/web/frontend/src/components/Dial.jsx
+++ b/services/web/frontend/src/components/Dial.jsx
@@ -29,18 +29,6 @@ function arcPath(cx, cy, r, a0, a1) {
   const sweep = a1 > a0 ? 1 : 0;
   return `M ${x0} ${y0} A ${r} ${r} 0 ${large} ${sweep} ${x1} ${y1}`;
 }
-function annulusPath(cx, cy, rIn, rOut) {
-  return [
-    `M ${cx - rOut} ${cy}`,
-    `a ${rOut} ${rOut} 0 1 0 ${rOut * 2} 0`,
-    `a ${rOut} ${rOut} 0 1 0 ${-rOut * 2} 0`,
-    `Z`,
-    `M ${cx - rIn} ${cy}`,
-    `a ${rIn} ${rIn} 0 1 0 ${rIn * 2} 0`,
-    `a ${rIn} ${rIn} 0 1 0 ${-rIn * 2} 0`,
-    `Z`,
-  ].join(" ");
-}
 
 export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
   const SIZE = 480;
@@ -53,6 +41,7 @@ export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
   const HANDLE_GRAB_R = 36;
 
   const svgRef = useRef(null);
+  const dragRef = useRef(false);
   const [drag, setDrag] = useState(false);
 
   const targetA = tempToAngle(targetC);
@@ -93,23 +82,25 @@ export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
     if (!svgRef.current) return;
     const [px, py] = svgCoords(e);
     if (!isOnRing(px, py)) return;
+    dragRef.current = true;
     setDrag(true);
     if (onDragStart) onDragStart();
     e.currentTarget.setPointerCapture(e.pointerId);
     applyAngle(px, py);
   }
   function moveDrag(e) {
-    if (!drag) return;
+    if (!dragRef.current) return;
     const [px, py] = svgCoords(e);
     applyAngle(px, py);
   }
   function endDrag(e) {
-    if (drag && onCommit) {
+    if (dragRef.current && onCommit) {
       const [px, py] = svgCoords(e);
       const a = Math.atan2(py - CY, px - CX);
       const c = angleToTemp(a);
       onCommit(Math.min(MAX_C, Math.max(MIN_C, Math.round(c * 2) / 2)));
     }
+    dragRef.current = false;
     setDrag(false);
     try { e.currentTarget.releasePointerCapture(e.pointerId); } catch (_) {}
   }
@@ -118,7 +109,8 @@ export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
   const [rx, ry] = polar(CX, CY, R_HANDLE, roomA);
 
   return (
-    <svg ref={svgRef} viewBox={`0 0 ${SIZE} ${SIZE}`} className={"dial-svg" + (drag ? " dragging" : "")}>
+    <svg ref={svgRef} viewBox={`0 0 ${SIZE} ${SIZE}`} className={"dial-svg" + (drag ? " dragging" : "")}
+         onPointerDown={startDrag} onPointerMove={moveDrag} onPointerUp={endDrag} onPointerCancel={endDrag}>
       <defs>
         <linearGradient id="ringGrad" gradientUnits="userSpaceOnUse" x1={CX - R} y1={CY} x2={CX + R} y2={CY}>
           <stop offset="0%"   stopColor="var(--cool)" stopOpacity="0.5" />
@@ -160,12 +152,6 @@ export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
         </g>
       </g>
 
-      {/* Hit ring — invisible doughnut between HIT_INNER and HIT_OUTER. Touches in the
-          center fall through to the page, so vertical scrolling works there. */}
-      <path d={annulusPath(CX, CY, HIT_INNER, HIT_OUTER)}
-            fill="black" fillOpacity="0" fillRule="evenodd"
-            style={{ pointerEvents: "fill", touchAction: "none", cursor: "grab" }}
-            onPointerDown={startDrag} onPointerMove={moveDrag} onPointerUp={endDrag} onPointerCancel={endDrag} />
     </svg>
   );
 }

--- a/services/web/frontend/src/styles.css
+++ b/services/web/frontend/src/styles.css
@@ -292,6 +292,8 @@ body {
 .dial-svg {
   width: 100%; height: 100%;
   user-select: none;
+  touch-action: none;
+  cursor: grab;
 }
 .dial-svg.dragging { cursor: grabbing; }
 
@@ -482,6 +484,7 @@ body {
   width: 100%;
   height: 180px;
   display: block;
+  touch-action: none;
 }
 .history .grid-line { stroke: var(--line); stroke-width: 1; stroke-dasharray: 2 4; }
 .history .axis { font-family: var(--font-mono); font-size: 10px; fill: var(--ink-3); letter-spacing: 0.04em; }


### PR DESCRIPTION
## Summary

- **Dial broken on Chrome/Edge mobile**: Chromium ignores `touch-action` set on SVG child elements (`<path>`, etc.) — it was being set on the invisible hit-ring path after the `ae67a8c` refactor. Chrome used the SVG root's default `touch-action: auto`, so any touch with a vertical component triggered `pointercancel` (scroll takeover), killing the drag. Fixed by moving the four pointer-event handlers back to the `<svg>` element and setting `touch-action: none; cursor: grab` on `.dial-svg` in CSS, which Chrome *does* honour. Also replaced the `drag` React state check in `moveDrag`/`endDrag` with a `useRef` flag to remove a stale-closure race on the first `pointermove`.
- **History tooltip broken on Chrome/Edge mobile**: The `HistoryGraph` SVG had no `touch-action`, defaulting to `auto`. Chrome fired `pointercancel` instead of `pointermove` during a touch-scrub, so the hover tooltip never appeared. Fixed by adding `touch-action: none` to `.history` in CSS.
- Firefox worked in both cases because it honours `touch-action` on SVG child elements; Chrome/Edge do not.

## Test plan

- [ ] Open on Chrome mobile (Android or iOS CriOS) — drag the temperature ring continuously without it freezing after the first move
- [ ] Touch-scrub the history graph — tooltip appears showing time and temperature values
- [ ] Confirm desktop mouse interaction still works for both
- [ ] Confirm Firefox mobile still works for both
- [ ] Confirm page scroll still works by swiping below the dial / outside the history graph

https://claude.ai/code/session_012tBxPGrq3UiA9RF9sUix5B

---
_Generated by [Claude Code](https://claude.ai/code/session_012tBxPGrq3UiA9RF9sUix5B)_