### PR TITLE
Restore center-passthrough scroll on dial; fix Chrome via native touchstart

### DIFF
--- a/services/web/frontend/src/components/Dial.jsx
+++ b/services/web/frontend/src/components/Dial.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const TAU = Math.PI * 2;
 const MIN_C = 10;
@@ -29,6 +29,18 @@ function arcPath(cx, cy, r, a0, a1) {
   const sweep = a1 > a0 ? 1 : 0;
   return `M ${x0} ${y0} A ${r} ${r} 0 ${large} ${sweep} ${x1} ${y1}`;
 }
+function annulusPath(cx, cy, rIn, rOut) {
+  return [
+    `M ${cx - rOut} ${cy}`,
+    `a ${rOut} ${rOut} 0 1 0 ${rOut * 2} 0`,
+    `a ${rOut} ${rOut} 0 1 0 ${-rOut * 2} 0`,
+    `Z`,
+    `M ${cx - rIn} ${cy}`,
+    `a ${rIn} ${rIn} 0 1 0 ${rIn * 2} 0`,
+    `a ${rIn} ${rIn} 0 1 0 ${-rIn * 2} 0`,
+    `Z`,
+  ].join(" ");
+}
 
 export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
   const SIZE = 480;
@@ -41,6 +53,7 @@ export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
   const HANDLE_GRAB_R = 36;
 
   const svgRef = useRef(null);
+  const ringRef = useRef(null);
   const dragRef = useRef(false);
   const [drag, setDrag] = useState(false);
 
@@ -78,6 +91,22 @@ export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
     return false;
   }
 
+  // Chrome and Edge ignore touch-action set on SVG child elements, so the
+  // inline touchAction: "none" on the ring path is a no-op there — Chromium
+  // falls back to the SVG root's auto, treats vertical drags as scrolls and
+  // fires pointercancel. React's onTouchStart is passive so preventDefault
+  // does nothing; attach a non-passive native listener instead. The ring
+  // path uses pointer-events: fill with evenodd, so this only fires when the
+  // touch starts on the ring — center touches still fall through to the page
+  // and scroll natively.
+  useEffect(() => {
+    const ring = ringRef.current;
+    if (!ring) return;
+    const onTouchStart = (e) => { e.preventDefault(); };
+    ring.addEventListener("touchstart", onTouchStart, { passive: false });
+    return () => ring.removeEventListener("touchstart", onTouchStart);
+  }, []);
+
   function startDrag(e) {
     if (!svgRef.current) return;
     const [px, py] = svgCoords(e);
@@ -109,8 +138,7 @@ export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
   const [rx, ry] = polar(CX, CY, R_HANDLE, roomA);
 
   return (
-    <svg ref={svgRef} viewBox={`0 0 ${SIZE} ${SIZE}`} className={"dial-svg" + (drag ? " dragging" : "")}
-         onPointerDown={startDrag} onPointerMove={moveDrag} onPointerUp={endDrag} onPointerCancel={endDrag}>
+    <svg ref={svgRef} viewBox={`0 0 ${SIZE} ${SIZE}`} className={"dial-svg" + (drag ? " dragging" : "")}>
       <defs>
         <linearGradient id="ringGrad" gradientUnits="userSpaceOnUse" x1={CX - R} y1={CY} x2={CX + R} y2={CY}>
           <stop offset="0%"   stopColor="var(--cool)" stopOpacity="0.5" />
@@ -152,6 +180,13 @@ export function Dial({ targetC, roomC, onChange, onCommit, onDragStart }) {
         </g>
       </g>
 
+      {/* Hit ring — invisible doughnut between HIT_INNER and HIT_OUTER. Touches in the
+          center fall through to the page, so vertical scrolling works there. */}
+      <path ref={ringRef}
+            d={annulusPath(CX, CY, HIT_INNER, HIT_OUTER)}
+            fill="black" fillOpacity="0" fillRule="evenodd"
+            style={{ pointerEvents: "fill", touchAction: "none", cursor: "grab" }}
+            onPointerDown={startDrag} onPointerMove={moveDrag} onPointerUp={endDrag} onPointerCancel={endDrag} />
     </svg>
   );
 }

--- a/services/web/frontend/src/styles.css
+++ b/services/web/frontend/src/styles.css
@@ -292,8 +292,6 @@ body {
 .dial-svg {
   width: 100%; height: 100%;
   user-select: none;
-  touch-action: none;
-  cursor: grab;
 }
 .dial-svg.dragging { cursor: grabbing; }
 
@@ -484,7 +482,7 @@ body {
   width: 100%;
   height: 180px;
   display: block;
-  touch-action: none;
+  touch-action: pan-y;
 }
 .history .grid-line { stroke: var(--line); stroke-width: 1; stroke-dasharray: 2 4; }
 .history .axis { font-family: var(--font-mono); font-size: 10px; fill: var(--ink-3); letter-spacing: 0.04em; }


### PR DESCRIPTION
## Summary

- Restores the evenodd annulus hit-ring `<path>` on the dial so touches through the dial centre still fall through to the page (vertical scroll preserved)
- Attaches a non-passive native `touchstart` listener via `useEffect` on the ring path — the only way to call `preventDefault()` on Chrome/Edge, which silently ignores `preventDefault` in React's passive `onTouchStart`
- Changes `.history` `touch-action` to `pan-y` so the history tooltip works on touch while still allowing vertical page scroll over the graph

## What broke in PR #20

PR #20 moved pointer handlers to the `<svg>` root and added `touch-action: none` to `.dial-svg`. That fixed the Chrome drag bug but blocked all scrolling through the dial area, including the centre where users swipe to scroll the page.

## How this fixes it

The annulus path (`fillRule="evenodd"`) makes the centre hole event-transparent — centre touches fall through to the page. The non-passive `touchstart` listener on the ring path calls `preventDefault()` before Chrome can classify the gesture as a scroll, so `pointermove` fires correctly on ring drags without blocking centre scroll.

---
_Generated by [Claude Code](https://claude.ai/code/session_012tBxPGrq3UiA9RF9sUix5B)_